### PR TITLE
update to Change-Id: I25a4d49f19e8067d114d56c100963d48d9d21e66

### DIFF
--- a/smart-home-provider/frontend/src/my-app.html
+++ b/smart-home-provider/frontend/src/my-app.html
@@ -234,6 +234,7 @@ limitations under the License.
 
     <script>
         var nextDeviceId = 0;
+        var devices={};
 
         function getNextDeviceId() {
             return nextDeviceId++;
@@ -295,7 +296,9 @@ limitations under the License.
                                     'Authorization': 'Bearer ' + AUTH_TOKEN
                                 }
                             };
-                            return fetch(SMART_HOME_PROVIDER_CLOUD_ENDPOINT + '/reset-devices', options)
+                            fetch(SMART_HOME_PROVIDER_CLOUD_ENDPOINT + '/reset-devices', options);
+                            this._refresh();
+                            return;
                         });
                 });
             },
@@ -345,25 +348,24 @@ limitations under the License.
                     .then(function(response) {
                         return response.json();
                     }).then(function(json) {
-                        const uid = json.uid;
-                        delete json.uid;
                         for (const key in json) {
                             devices[key] = json[key];
                         }
                         console.log(devices);
-                        return app._handleRefresh(app, uid);
+                        const app = document.querySelector('my-app');
+                        return app._handleRefresh(app);
                     });
             },
 
-            _handleRefresh: function (app, uid) {
+            _handleRefresh: function (app) {
                 if (Object.keys(devices).length == 0) {
                     console.log("no devices");
                 } else {
                     for (const id of Object.keys(devices)) {
                         devices[id].id = id;
                         delete devices[id].properties.id;
-                        devices[id].states.on = false;
-                        devices[id].states.online = false;
+                        //devices[id].states.on = false;
+                        //devices[id].states.online = false;
                         switch(devices[id].properties.type) {
                             case 'action.devices.types.LIGHT':
                                 app._addLight(null, devices[id]);

--- a/smart-home-provider/frontend/src/smart-device.html
+++ b/smart-home-provider/frontend/src/smart-device.html
@@ -152,7 +152,7 @@ limitations under the License.
             _handleCloud() {
                 this.device.states.online = !this.device.states.online;
                 this._handleRegister();
-                this._changeEventSource();
+                // already called in function above //this._changeEventSource();
             }
 
             _handleRegister() {
@@ -182,6 +182,9 @@ limitations under the License.
                         app.removeDevice(this.type, i);
                     }
                 }
+                //  page has to be refreshed after a device has been removed. If not when you add a new device it won't be sync with the server !!
+                location.reload();
+
             }
 
             _execNameOrNicknameChange(event) {


### PR DESCRIPTION
A new flag has been introduced "Config.enableReset". By default, it's set to true but if you would like the devices setup to remain after a page refresh you have to put this flag to false.
It works server-side and the existing devices are not reset but on the client side the refresh function is not triggered, function that should show up the existing devices.
I added the trigger for this function call as well as some necessary adjustments.