### PR TITLE
Replace ngrok with local tunnel for an improved developer experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,14 +108,14 @@ enable it for cloud control.
 #### Start testing
 
 1. Back in the Actions Console, select your smart home action and enter
-   the URL for fulfillment, e.g. https://xyz123.ngrok.io/smarthome
+   the URL for fulfillment, e.g. https://smart-home-demo.localtunnel.me/smarthome
 1. Click Add under Account Linking.
 1. Select 'Authorization Code' for Grant Type.
 1. Under Client Information, enter the client ID and secret from earlier.
 1. The Authorization URL is the hosted URL of your app with '/oauth' as the
-path, e.g. https://xyz123.ngrok.io/oauth
+path, e.g. https://smart-home-demo.localtunnel.me/oauth
 1. The Token URL is the hosted URL of your app with '/token' as the path,
-e.g. https://xyz123.ngrok.io/token
+e.g. https://smart-home-demo.localtunnel.me/token
 1. Enter any remaining necessary information you might need for
 authentication your app. Then Save.
 1. Press the **TEST DRAFT** button to begin testing this app.
@@ -130,7 +130,7 @@ to create the project in the Actions Console, enter your Assistant settings.
 1. Log in to your service.
 1. Start using the Google Assistant in the Actions Console to control your devices. Try saying 'turn my lights on'.
 
-:information_source: Assistant will only provide you control over items that are registered, so if you visit your front end https://xyz123.ngrok.io and click the add icon to create a device your server will receive a new SYNC command.
+:information_source: Assistant will only provide you control over items that are registered, so if you visit your front end https://smart-home-demo.localtunnel.me and click the add icon to create a device your server will receive a new SYNC command.
 
 
 ### Steps for testing with mock-assistant-platform

--- a/smart-home-provider/cloud/config-provider.js
+++ b/smart-home-provider/cloud/config-provider.js
@@ -17,6 +17,8 @@
 let Config = {};
 
 Config.devPortSmartHome = '3000';
+// Change this to a unique subdomain to ensure it won't change during your tests
+Config.devSubdomainSmartHome = 'smart-home-demo';
 // Client id that Google will use
 Config.smartHomeProviderGoogleClientId = 'ZxjqWpsYj3';
 // Client secret that Google will use
@@ -45,6 +47,7 @@ function init() {
 }
 init();
 
+exports.devSubdomainSmartHome = Config.devSubdomainSmartHome;
 exports.devPortSmartHome = Config.devPortSmartHome;
 exports.smartHomeProviderGoogleClientId =
   Config.smartHomeProviderGoogleClientId;

--- a/smart-home-provider/cloud/smart-home-provider-cloud.js
+++ b/smart-home-provider/cloud/smart-home-provider-cloud.js
@@ -15,7 +15,7 @@ const bodyParser = require('body-parser');
 const express = require('express');
 const fetch = require('node-fetch');
 const morgan = require('morgan');
-const ngrok = require('ngrok');
+const localtunnel = require('localtunnel');
 const session = require('express-session');
 
 // internal app deps
@@ -593,31 +593,37 @@ const server = app.listen(appPort, () => {
   console.log('Smart Home Cloud and App listening at %s:%s', host, port);
 
   if (config.isLocal) {
-    ngrok.connect(config.devPortSmartHome, (err, url) => {
+    localtunnel(config.devPortSmartHome, {subdomain: config.devSubdomainSmartHome}, (err, tunnel) => {
       if (err) {
-        console.log('ngrok err', err);
+        console.log('localtunnel err', err);
+        process.exit();
+      }
+
+      if (tunnel.url !== 'https://' + config.devSubdomainSmartHome + '.localtunnel.me') {
+        console.log('localtunnel subdomain already in use, specify a different one in' +
+          ' config-provider.js', config.devSubdomainSmartHome);
         process.exit();
       }
 
       console.log('|###################################################|');
       console.log('|                                                   |');
-      console.log('|        COPY & PASTE NGROK URL BELOW:              |');
+      console.log('|     COPY & PASTE LOCALTUNNEL URL BELOW:           |');
       console.log('|                                                   |');
-      console.log('|          ' + url + '                |');
+      console.log('|     ' + tunnel.url + '        |');
       console.log('|                                                   |');
       console.log('|###################################################|');
 
       console.log('=====');
       console.log('Visit the Actions on Google console at http://console.actions.google.com');
       console.log('Replace the webhook URL in the Actions section with:');
-      console.log('    ' + url + '/smarthome');
+      console.log('    ' + tunnel.url + '/smarthome');
 
       console.log('In the console, set the Authorization URL to:');
-      console.log('    ' + url + '/oauth');
+      console.log('    ' + tunnel.url + '/oauth');
 
       console.log('');
       console.log('Then set the Token URL to:');
-      console.log('    ' + url + '/token');
+      console.log('    ' + tunnel.url + '/token');
       console.log('');
 
       console.log('Finally press the \'TEST DRAFT\' button');

--- a/smart-home-provider/cloud/smart-home-provider-cloud.js
+++ b/smart-home-provider/cloud/smart-home-provider-cloud.js
@@ -605,13 +605,10 @@ const server = app.listen(appPort, () => {
         process.exit();
       }
 
-      console.log('|###################################################|');
-      console.log('|                                                   |');
-      console.log('|     COPY & PASTE LOCALTUNNEL URL BELOW:           |');
-      console.log('|                                                   |');
-      console.log('|     ' + tunnel.url + '        |');
-      console.log('|                                                   |');
-      console.log('|###################################################|');
+      console.log('###################################################');
+      console.log('COPY & PASTE LOCALTUNNEL URL BELOW:');
+      console.log(`    ${tunnel.url}`);
+      console.log('###################################################');
 
       console.log('=====');
       console.log('Visit the Actions on Google console at http://console.actions.google.com');

--- a/smart-home-provider/cloud/smart-home-provider-cloud.js
+++ b/smart-home-provider/cloud/smart-home-provider-cloud.js
@@ -613,14 +613,14 @@ const server = app.listen(appPort, () => {
       console.log('=====');
       console.log('Visit the Actions on Google console at http://console.actions.google.com');
       console.log('Replace the webhook URL in the Actions section with:');
-      console.log('    ' + tunnel.url + '/smarthome');
+      console.log(`    ${tunnel.url}/smarthome`);
 
       console.log('In the console, set the Authorization URL to:');
-      console.log('    ' + tunnel.url + '/oauth');
+      console.log(`    ${tunnel.url}/oauth`);
 
       console.log('');
       console.log('Then set the Token URL to:');
-      console.log('    ' + tunnel.url + '/token');
+      console.log(`    ${tunnel.url}/token`);
       console.log('');
 
       console.log('Finally press the \'TEST DRAFT\' button');

--- a/smart-home-provider/package.json
+++ b/smart-home-provider/package.json
@@ -21,7 +21,6 @@
     "googleapis": "^27.0.0",
     "localtunnel": "1.9.0",
     "morgan": "^1.9.0",
-    "ngrok": "^2.3.0",
     "node-fetch": "^1.6.3"
   },
   "devDependencies": {

--- a/smart-home-provider/package.json
+++ b/smart-home-provider/package.json
@@ -19,6 +19,7 @@
     "express": "^4.16.0",
     "express-session": "^1.15.6",
     "googleapis": "^27.0.0",
+    "localtunnel": "1.9.0",
     "morgan": "^1.9.0",
     "ngrok": "^2.3.0",
     "node-fetch": "^1.6.3"


### PR DESCRIPTION
While running the demo and developing locally, there's a small issue that makes it tedious. The `ngrok` subdomain can only be specified if you pay for that feature. As a result, every time you start the dev server  you get a new subdomain and you have to update the settings for both the _Action_ and _Account Linking_ sections for your action on the _Actions on Google Console_.

I've been using `localtunnel` for a long time, which works exactly like `ngrok` but allows using an arbitrary subdomain at no cost.

This PR replaces `ngrok` with`localtunnel` with no other side-effects.