### PR TITLE
Allow client_id and client_secret to take from request's header

### DIFF
--- a/smart-home-provider/cloud/auth-provider.js
+++ b/smart-home-provider/cloud/auth-provider.js
@@ -304,6 +304,7 @@ Auth.registerAuth = function(app) {
 
 /**
  * Decode authorization into client_id and client_secret.
+ * @param {Object} req ExpressJS request object
  * @return {{}}
  * {
  *   client_id: "CLIENT_ID",
@@ -311,22 +312,23 @@ Auth.registerAuth = function(app) {
  * }
  */
 function getHeaderAuthorization(req){
-  let headerAuthor = {};
-    try{
-      if(!!req.headers.authorization){
-        let authorizationString = Buffer.from(req.headers.authorization.split(" ")[1], 'base64').toString();
-        if(!!authorizationString){
-          let authorizationArray = authorizationString.split(':');
-          headerAuthor = {
-            client_id: authorizationArray[0],
-            client_secret: authorizationArray[1]
-          }
-        }
-      }
-    }catch(e){
+  try{
+    if(!req.headers.authorization)
       return {};
+
+    const authorizationString = Buffer.from(req.headers.authorization.split(" ")[1], 'base64').toString();
+    if(!authorizationString)
+      return {};
+
+    const [client_id, client_secret] = authorizationString.split(':');
+    return {
+      client_id,
+      client_secret
     }
-    return headerAuthor;
+  }catch(e){
+    return {};
+  }
+  return {};
 }
 
 /**
@@ -334,7 +336,9 @@ function getHeaderAuthorization(req){
  *   - Request's query string
  *   - Request's body
  *   - Request's header (from `authorization`)
- * @return string
+ * @param {string} key Client's key
+ * @param {Object} req ExpressJS request object
+ * @return {(string|undefined)} Return either client's value or `undefined` if it doesn't exist.
  */
 function getClientValue(key, req){
   if(!!req.query[key])
@@ -342,7 +346,7 @@ function getClientValue(key, req){
   if(!!req.body[key])
     return req.body[key];
 
-  let headerAuthor = getHeaderAuthorization(req);
+  const headerAuthor = getHeaderAuthorization(req);
   if(!!headerAuthor[key])
     return headerAuthor[key];
 

--- a/smart-home-provider/cloud/auth-provider.js
+++ b/smart-home-provider/cloud/auth-provider.js
@@ -324,6 +324,7 @@ function getHeaderAuthorization(req){
       client_secret
     }
   } catch (e) {
+    console.error("Error while parsing authorization header", e);
     return {};
   }
   return {};

--- a/smart-home-provider/cloud/auth-provider.js
+++ b/smart-home-provider/cloud/auth-provider.js
@@ -312,20 +312,18 @@ Auth.registerAuth = function(app) {
  * }
  */
 function getHeaderAuthorization(req){
-  try{
-    if(!req.headers.authorization)
-      return {};
+  try {
+    if (!req.headers.authorization) return {};
 
     const authorizationString = Buffer.from(req.headers.authorization.split(" ")[1], 'base64').toString();
-    if(!authorizationString)
-      return {};
+    if(!authorizationString) return {};
 
     const [client_id, client_secret] = authorizationString.split(':');
     return {
       client_id,
       client_secret
     }
-  }catch(e){
+  } catch (e) {
     return {};
   }
   return {};
@@ -341,14 +339,11 @@ function getHeaderAuthorization(req){
  * @return {(string|undefined)} Return either client's value or `undefined` if it doesn't exist.
  */
 function getClientValue(key, req){
-  if(!!req.query[key])
-    return req.query[key];
-  if(!!req.body[key])
-    return req.body[key];
+  if(!!req.query[key]) return req.query[key];
+  if(!!req.body[key]) return req.body[key];
 
   const headerAuthor = getHeaderAuthorization(req);
-  if(!!headerAuthor[key])
-    return headerAuthor[key];
+  if(!!headerAuthor[key]) return headerAuthor[key];
 
   return undefined;
 }


### PR DESCRIPTION
In account's linking of Google home action, there is an option to let "Google to transmit clientID and secret via HTTP basic auth header". Which mean, instead of submitting `client_id` and `client_secret` via request's body, Google'll submit as base64-encoded Basic `Authorization` request's header. And it makes the application to throw 'missing required parameter' error when user make a SYNC request.

**
![image](https://user-images.githubusercontent.com/3356814/55241048-dc734c00-526c-11e9-98b3-c381c339d43b.png)
**

In this PR, I made 2 functions to interpret the `Authorization` request's header by decode base64-based token into `client_id` and `client_secret`. 

Then, another function returns the request's key from the following source: query string, request POST body, and request header. (This function is a substitute of the old inline ternary operator to make it look easier to read. )

This PR is already discussed in issue #320 

If you have any suggestion regarding this issue/PR, please reply to the message.

Thank you.