### PR TITLE
Fix report sate bad argument error when spectrumRgb equals 0 (black)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -81,10 +81,11 @@ async function reportState(agentUserId: string, deviceId: string,
   // Report state back to Homegraph
   // Do state name replacement for ColorSetting trait
   // See https://developers.google.com/assistant/smarthome/traits/colorsetting#device-states
-  if (states.color && states.color.spectrumRgb) {
+  if (states.color && typeof states.color.spectrumRgb === 'number') {
     states.color.spectrumRGB = states.color.spectrumRgb
-    states.color.spectrumRgb = undefined
+    delete states.color.spectrumRgb
   }
+
   return await app.reportState({
     agentUserId,
     requestId: Math.random().toString(),


### PR DESCRIPTION
When user creates an RGB light it has default `spectrumRgb` value set to `0` wich cause an `BAD_ARGUMENT` error because `spectrumRgb` is not converted to `spectrumRGB`.